### PR TITLE
[Feat] 메인화면 구현 및 bottom navi 숨기기

### DIFF
--- a/app/src/main/java/com/example/onenthapp/HomeFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/HomeFragment.kt
@@ -6,58 +6,56 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.annotation.UiThread
 import androidx.fragment.app.Fragment
-import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.PopupMenu
-import com.google.android.material.appbar.MaterialToolbar
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.appcompat.view.menu.MenuPopupHelper
-
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.onenthapp.databinding.FragmentHomeBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
 
 class HomeFragment : Fragment(), OnMapReadyCallback {
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
+    private var sheetInitialized = false
     private var naverMap: NaverMap? = null
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<*>
+//    private val searchAdapter = SearchAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val view = inflater.inflate(R.layout.fragment_home, container, false)
-        return view    }
+    ): View {
+        // 1) 지도 초기화
+        val fm = childFragmentManager
+        val mapFragment = fm.findFragmentById(R.id.map) as MapFragment?
+            ?: MapFragment.newInstance().also {
+                fm.beginTransaction().add(R.id.map, it).commit()
+            }
+        mapFragment.getMapAsync(this)
+
+        _binding = FragmentHomeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
     @SuppressLint("RestrictedApi", "DiscouragedPrivateApi")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val fm = childFragmentManager
-        var mapFragment = fm.findFragmentById(R.id.map) as MapFragment?
-            ?: MapFragment.newInstance().also {
-                fm.beginTransaction().add(R.id.map, it).commit()
-            }
-
-        mapFragment.getMapAsync(this) // this는 OnMapReadyCallback을 구현한 HomeFragment 자신
-
-//// 1) Toolbar menu inflate
-//        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar_home)
-//        toolbar.inflateMenu(R.menu.menu_home)
-//        toolbar.setOnMenuItemClickListener { item ->
-//            if (item.itemId == R.id.action_notifications) {
-//                // TODO: 알림 화면으로 이동
-//            }
-//            true
-//        }
-
-        // 2) 드롭다운 PopupMenu
-        val arrow = view.findViewById<ImageView>(R.id.iv_arrow)
-        val titleContainer = view.findViewById<LinearLayout>(R.id.ll_title_container)
+        // 드롭다운 PopupMenu
         val popup = PopupMenu(
             ContextThemeWrapper(requireContext(), R.style.Theme_OneNthApp),
-            arrow,
+            binding.ivArrow,
             Gravity.END
         ).apply {
             menuInflater.inflate(R.menu.menu_title_dropdown, menu)
@@ -76,15 +74,43 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             }
             setOnDismissListener {
                 // 팝업 닫힐 때 화살표 복귀
-                arrow.animate().rotation(0f).start()
+                binding.ivArrow.animate().rotation(0f).start()
             }
         }
-
-        // 4) 클릭하면 화살표 회전 + 팝업 보여주기
-        arrow.setOnClickListener {
-            arrow.animate().rotation(180f).start()
+        // 화살표 회전 + 팝업 보여주기
+        binding.ivArrow.setOnClickListener {
+            binding.ivArrow.animate().rotation(180f).start()
             popup.show()
         }
+        val searchList = binding.rvSearchResults
+        searchList.layoutManager = LinearLayoutManager(requireContext())
+//        searchList.adapter = searchAdapter
+
+        // 검색창 엔터 리스너
+        binding.searchBarEt.setOnEditorActionListener { et, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                performSearch(et.text.toString())
+                // 처음 검색할 때만 BottomSheet 보이기 + Behavior 초기화
+                if (!sheetInitialized) {
+                    initBottomSheet()
+                    sheetInitialized = true
+                }
+                bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+                true
+            } else false
+        }
+//        // 탭 레이아웃 - 마커 교체
+//        binding.tabLayoutHome.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+//            override fun onTabSelected(tab: TabLayout.Tab) {
+//                when (tab.position) {
+//                    0 -> showMarkers(markerListForBuy)
+//                    1 -> showMarkers(markerListForShare)
+//                }
+//            }
+//            override fun onTabUnselected(tab: TabLayout.Tab) {}
+//            override fun onTabReselected(tab: TabLayout.Tab) {}
+//        })
+
     }
 
     @UiThread
@@ -92,7 +118,82 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         // 네이버 지도 객체를 받고 필요한 설정
         this.naverMap = naverMap
         naverMap.setLayerGroupEnabled(NaverMap.LAYER_GROUP_TRANSIT, true)
-        // 다른 지도 관련 로직 추가 (예: 마커 추가, 카메라 이동 등)
+        //showMarkers(emptyList())
     }
 
+//    private fun showMarkers(data: List<T>) {
+//        naverMap?.let { map ->
+//            map.clear()
+//            list.forEach { loc ->
+//                Marker().apply {
+//                    position = loc.toLatLng()
+//                    captionText = loc.title
+//                    this.map = map
+//                }
+//            }
+//        }
+//        naverMap?.apply {
+//            clear()
+//            data.forEach { loc ->
+//                Marker().apply {
+//                    position = loc.toLatLng()
+//                    captionText = loc.title
+//                    map = this@apply
+//                }
+//            }
+//        }
+//    }
+
+    private fun performSearch(query: String) {
+        // TODO: 실제 API 연동 대신 더미 데이터 생성
+//        val results = dummySearchData(query)
+//
+//        // 지도 마커 갱신
+//        showMarkers(results)
+//        // 검색 결과 리스트 갱신
+//        searchAdapter.submitList(results)
+        // BottomSheet 펼치기
+        //bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+    private fun initBottomSheet() {
+        val sheet = binding.bottomSheet
+        // 1) 뷰 보이기
+        sheet.visibility = View.VISIBLE
+        // BottomSheet 초기화
+        bottomSheetBehavior = BottomSheetBehavior.from(binding.bottomSheet).apply {
+            isHideable = false
+            skipCollapsed = false
+            state = BottomSheetBehavior.STATE_COLLAPSED // 초기에 341 중간 높이
+        }
+
+//        // 2) halfExpandedOffset 계산 (341dp 높이)
+//        binding.root.post {
+//            val parentH = binding.root.height
+//            val halfH   = resources.getDimensionPixelSize(R.dimen.bottom_sheet_half_height)
+//        }
+        bottomSheetBehavior.addBottomSheetCallback(object: BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) {
+                val isExpanded = newState == BottomSheetBehavior.STATE_EXPANDED
+                binding.minimalContainer.visibility  = if (isExpanded) View.GONE else View.VISIBLE
+                binding.expandedContainer.visibility = if (isExpanded) View.VISIBLE else View.GONE
+                binding.scrollBar.visibility         = if (isExpanded) View.GONE else View.VISIBLE
+            }
+            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+        })
+        // RecyclerView
+        binding.rvSearchResults.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+//            adapter = searchAdapter
+        }
+
+        binding.toolbarSearch.setNavigationOnClickListener {
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+//        binding.toolbarSearch.setOnMenuItemClickListener {
+//            if (it.itemId == R.id.action_close) {
+//                behavior.state = BottomSheetBehavior.STATE_COLLAPSED
+//                true
+//            } else false
+//        }
+        }
 }

--- a/app/src/main/java/com/example/onenthapp/MainActivity.kt
+++ b/app/src/main/java/com/example/onenthapp/MainActivity.kt
@@ -39,13 +39,15 @@ class MainActivity : AppCompatActivity() {
 
         // FAB 클릭시 상품 등록 화면으로 이동
         binding.fabAdd.setOnClickListener {
-            Log.d("MainActivity", "FAB clicked!")
             navController.navigate(R.id.plusFragment)
         }
         navController.addOnDestinationChangedListener { _, dest, _ ->
             val hideOn = dest.id == R.id.plusFragment
-            binding.bottomNavigationView.visibility = if (hideOn) View.GONE else View.VISIBLE
-            binding.fabAdd.visibility            = if (hideOn) View.GONE else View.VISIBLE
+            val hideOn2 = dest.id == R.id.statsFragment
+            val hideOn3 = dest.id == R.id.chatFragment
+            val hideOn4 = dest.id == R.id.mypageFragment
+            binding.bottomNavigationView.visibility = if (hideOn || hideOn2 || hideOn3 || hideOn4) View.GONE else View.VISIBLE
+            binding.fabAdd.visibility = if (hideOn || hideOn2 || hideOn3 || hideOn4) View.GONE else View.VISIBLE
         }
 
     }

--- a/app/src/main/res/drawable/bg_bottom_sheet.xml
+++ b/app/src/main/res/drawable/bg_bottom_sheet.xml
@@ -1,0 +1,17 @@
+<!--<vector xmlns:android="http://schemas.android.com/apk/res/android"-->
+<!--    android:width="393dp"-->
+<!--    android:height="355dp"-->
+<!--    android:viewportWidth="393"-->
+<!--    android:viewportHeight="355">-->
+<!--  <path-->
+<!--      android:pathData="M0,64C0,36.39 22.39,14 50,14H343C370.61,14 393,36.39 393,64V355H0V64Z"-->
+<!--      android:fillColor="#ffffff"/>-->
+<!--</vector>-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+<solid android:color="@color/main_white"/>
+<corners
+    android:topLeftRadius="50dp"
+    android:topRightRadius="50dp"
+    android:bottomLeftRadius="0dp"
+    android:bottomRightRadius="0dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         app:itemIconTint="@drawable/bottom_nav_color_selector"
         app:labelVisibilityMode="unlabeled"
         app:menu="@menu/bottom_nav_menu"
-        android:elevation="5dp"
+        android:elevation="10dp"
         />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -37,7 +37,7 @@
         app:layout_anchorGravity="top|center_horizontal"
         android:src="@drawable/ic_navigation_plus"
         app:tint="@null"
-        app:elevation="10dp"
+        app:elevation="3dp"
         app:useCompatPadding="false" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,6 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="75dp"
         app:defaultNavHost="true"
         app:navGraph="@navigation/nav_graph" />
 
@@ -20,12 +19,12 @@
         android:layout_height="75dp"
         android:layout_gravity="bottom"
         android:background="@drawable/ic_navigation_frame"
+        app:itemIconSize="26dp"
+        android:padding="0dp"
         app:itemIconTint="@drawable/bottom_nav_color_selector"
         app:labelVisibilityMode="unlabeled"
         app:menu="@menu/bottom_nav_menu"
         android:elevation="5dp"
-        android:clipToOutline="true"
-        android:outlineProvider="background"
         />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,150 +1,225 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@color/main_white"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <!-- 1) 툴바를 최상단에 추가 -->
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar_home"
-        android:layout_width="match_parent"
-        android:layout_height="70dp"
+
+    <!-- ─────── 기존 ConstraintLayout ─────── -->
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:background="@color/main_white"
-        app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <!-- a) 제목 + 드롭다운 -->
-        <LinearLayout
-            android:id="@+id/ll_title_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <!-- 1) 툴바를 최상단에 추가 -->
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_home"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal"
-            >
-            <ImageView
-                android:layout_width="27dp"
-                android:layout_height="23dp"
-                android:layout_marginStart="5dp"
-                android:layout_gravity="center_vertical"
-                android:src="@drawable/ic_main_logo" />
-            <TextView
-                android:id="@+id/tv_title"
-                android:layout_width="wrap_content"
-                android:layout_height="30dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="6dp"
-                android:layout_marginBottom="2dp"
-                style="@style/PretendardH1"
-                android:fontFamily="@font/pretendard_bold"
-                android:text="@string/title_n_1"
-                android:textColor="@color/main_black"
-                android:textSize="25sp" />
+            android:layout_height="70dp"
+            android:background="@color/main_white"
+            app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+            <!-- a) 제목 + 드롭다운 -->
+            <LinearLayout
+                android:id="@+id/ll_title_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+                <ImageView
+                    android:layout_width="27dp"
+                    android:layout_height="23dp"
+                    android:layout_marginStart="5dp"
+                    android:layout_gravity="center_vertical"
+                    android:src="@drawable/ic_main_logo" />
+                <TextView
+                    android:id="@+id/tv_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginBottom="2dp"
+                    style="@style/PretendardH1"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:text="@string/title_n_1"
+                    android:textColor="@color/main_black"
+                    android:textSize="25sp" />
 
-            <ImageView
-                android:id="@+id/iv_arrow"
-                android:layout_width="27dp"
-                android:layout_height="27dp"
-                android:src="@drawable/ic_down_green"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="7dp"/>
+                <ImageView
+                    android:id="@+id/iv_arrow"
+                    android:layout_width="27dp"
+                    android:layout_height="27dp"
+                    android:src="@drawable/ic_down_green"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="7dp"/>
 
-            <ImageButton
-                android:id="@+id/bt_notification"
-                android:layout_width="18dp"
-                android:layout_height="20dp"
-                android:layout_gravity="center"
-                android:layout_marginStart="179dp"
-                android:src="@drawable/ic_alarmbell" />
+                <ImageButton
+                    android:id="@+id/bt_notification"
+                    android:layout_width="18dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="179dp"
+                    android:src="@drawable/ic_alarmbell" />
 
-        </LinearLayout>
-    </com.google.android.material.appbar.MaterialToolbar>
+            </LinearLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
 
-    <!-- 2) 검색창 -->
-    <androidx.cardview.widget.CardView
-        android:layout_width="362dp"
-        android:layout_height="35dp"
-        android:layout_marginStart="19dp"
-        android:layout_marginEnd="19dp"
-        app:cardCornerRadius="10dp"
-        app:cardElevation="2dp"
-        android:id="@+id/search_bar"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_home"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        <!-- 2) 검색창 -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/search_bar"
+            android:layout_width="362dp"
+            android:layout_height="35dp"
+            android:layout_marginStart="19dp"
+            android:layout_marginEnd="19dp"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="3dp"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_home"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/search_gray"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp">
-
-            <ImageView
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_search_glasses"
-                app:tint="@color/text_search" />
-
-            <EditText
-                android:id="@+id/search_bar_et"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_weight="1"
-                android:background="@null"
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/search_gray"
                 android:gravity="center_vertical"
-                android:hint="@string/searchbar_guide"
-                android:textColor="@color/main_black"
-                android:textColorHighlight="@color/main_green_3"
-                android:textColorHint="@color/text_search"
-                android:textSize="14sp" />
+                android:orientation="horizontal"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_search_glasses"
+                    app:tint="@color/text_search" />
+
+                <EditText
+                    android:id="@+id/search_bar_et"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_weight="1"
+                    android:background="@null"
+                    android:gravity="center_vertical"
+                    android:hint="@string/searchbar_guide"
+                    android:textColor="@color/main_black"
+                    android:textColorHighlight="@color/main_green_3"
+                    android:textColorHint="@color/text_search"
+                    android:textSize="14sp"
+                    android:inputType="text"
+                    android:imeOptions="actionSearch"/>
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- 3) TabLayout -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout_home"
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:background="@color/main_white"
+            app:tabIndicatorFullWidth="false"
+            app:tabMode="fixed"
+            app:tabSelectedTextColor="@color/main_green"
+            app:tabIndicatorColor="@color/main_green"
+            app:tabTextAppearance="@style/TextAppearance.OneNthApp.Tab"
+            android:layout_marginTop="10dp"
+            app:layout_constraintTop_toBottomOf="@id/search_bar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="같이 사요"/>
+
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="함께 나눠요"/>
+
+        </com.google.android.material.tabs.TabLayout>
+
+        <!-- 4) 지도(전체를 차지하되, 위 컨텐츠 아래) -->
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/map"
+            android:name="com.naver.maps.map.MapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/tabLayout_home"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+        />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 5) 검색결과 바텀 시트 추가 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bottom_sheet"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@drawable/bg_bottom_sheet"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:behavior_hideable="false"
+        app:behavior_skipCollapsed="false"
+        app:behavior_peekHeight="@dimen/bottom_sheet_peek_height"
+        app:behavior_fitToContents="false"
+        app:behavior_expandedOffset="0dp"
+        android:elevation="20dp">
+        <View
+            android:id="@+id/scroll_bar"
+            android:layout_width="60dp"
+            android:layout_height="4dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintTop_toTopOf="@id/bottom_sheet"
+            app:layout_constraintStart_toStartOf="@id/bottom_sheet"
+            app:layout_constraintEnd_toEndOf="@id/bottom_sheet"
+            android:background="@drawable/ic_scrollbar_bar"/>
+
+        <!-- ① peek 상태에서만 보이는 컨테이너 -->
+        <FrameLayout
+            android:id="@+id/minimalContainer"
+            android:layout_width="match_parent"
+            android:layout_height="130dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <!-- 예: 카드 미리보기 등 -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </FrameLayout>
+
+        <!-- ② fully expanded 시 보이는 “새 화면” 컨테이너 -->
+        <LinearLayout
+            android:id="@+id/expandedContainer"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <!-- 검색 전용 AppBar -->
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_search"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:background="@color/main_white"
+                app:navigationIcon="@drawable/ic_arrow_left"
+            />
+
+            <!-- 검색 결과 리스트 -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_search_results"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
         </LinearLayout>
-    </androidx.cardview.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <!-- 3) TabLayout -->
-    <com.google.android.material.tabs.TabLayout
-        android:id="@+id/tabLayout_home"
-        android:layout_width="match_parent"
-        android:layout_height="60dp"
-        android:background="@color/main_white"
-        app:tabIndicatorFullWidth="false"
-        app:tabMode="fixed"
-        app:tabSelectedTextColor="@color/main_green"
-        app:tabIndicatorColor="@color/main_green"
-        app:tabTextAppearance="@style/TextAppearance.OneNthApp.Tab"
-        android:layout_marginTop="10dp"
-        app:layout_constraintTop_toBottomOf="@id/search_bar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <com.google.android.material.tabs.TabItem
-            android:id="@+id/tab_buy"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="같이 사요"/>
-
-        <com.google.android.material.tabs.TabItem
-            android:id="@+id/tab_share"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="함께 나눠요"/>
-
-    </com.google.android.material.tabs.TabLayout>
-
-    <!-- 4) 지도(전체를 차지하되, 위 컨텐츠 아래) -->
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/map"
-        android:name="com.naver.maps.map.MapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/tabLayout_home"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        style=""/>
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -63,7 +63,7 @@
 
     <!-- 2) 검색창 -->
     <androidx.cardview.widget.CardView
-        android:layout_width="0dp"
+        android:layout_width="362dp"
         android:layout_height="35dp"
         android:layout_marginStart="19dp"
         android:layout_marginEnd="19dp"
@@ -77,11 +77,11 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="horizontal"
+            android:background="@color/search_gray"
             android:gravity="center_vertical"
+            android:orientation="horizontal"
             android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            android:background="@color/search_gray">
+            android:paddingEnd="16dp">
 
             <ImageView
                 android:layout_width="24dp"
@@ -96,44 +96,55 @@
                 android:layout_marginStart="8dp"
                 android:layout_weight="1"
                 android:background="@null"
-                android:hint="@string/searchbar_guide"
-                android:textColorHint="@color/text_search"
-                android:textColor="@color/main_black"
                 android:gravity="center_vertical"
+                android:hint="@string/searchbar_guide"
+                android:textColor="@color/main_black"
                 android:textColorHighlight="@color/main_green_3"
-                android:textSize="14sp"/>
+                android:textColorHint="@color/text_search"
+                android:textSize="14sp" />
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 
     <!-- 3) TabLayout -->
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabLayout_home"
-        android:layout_width="0dp"
-        android:layout_height="70dp"
+        android:layout_width="match_parent"
+        android:layout_height="60dp"
+        android:background="@color/main_white"
         app:tabIndicatorFullWidth="false"
         app:tabMode="fixed"
+        app:tabSelectedTextColor="@color/main_green"
+        app:tabIndicatorColor="@color/main_green"
+        app:tabTextAppearance="@style/TextAppearance.OneNthApp.Tab"
+        android:layout_marginTop="10dp"
         app:layout_constraintTop_toBottomOf="@id/search_bar"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent">
 
-    <!-- 4) ViewPager2 -->
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/viewPager_home"
-        android:layout_width="0dp"
-        android:layout_height="200dp"
-        app:layout_constraintTop_toBottomOf="@id/tabLayout_home"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/tab_buy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="같이 사요"/>
 
-    <!-- 5) MapFragment -->
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/tab_share"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="함께 나눠요"/>
+
+    </com.google.android.material.tabs.TabLayout>
+
+    <!-- 4) 지도(전체를 차지하되, 위 컨텐츠 아래) -->
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/map"
         android:name="com.naver.maps.map.MapFragment"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/viewPager_home"
+        app:layout_constraintTop_toBottomOf="@id/tabLayout_home"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        style=""/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="popup_menu_width">158dp</dimen>
+    <dimen name="bottom_sheet_peek_height">130dp</dimen>
+    <dimen name="bottom_sheet_half_height">341dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -129,7 +129,11 @@
         <item name="android:textSize">12sp</item>
     </style>
 
-
+    <!-- 탭 전체에 적용할 TextAppearance -->
+    <style name="TextAppearance.OneNthApp.Tab" parent="TextAppearance.Design.Tab">
+        <item name="android:fontFamily">@font/pretendard_bold</item>
+        <item name="android:textSize">16sp</item>
+    </style>
 
     <style name="PretendardBody5">
         <item name="android:fontFamily">@font/pretendard_regular</item>


### PR DESCRIPTION
## #️⃣ Issue Number

#10 #22 

## 📝 요약(Summary)

- fragment 전체화면으로 늘리고 bottom navi 숨기기
- 지도 아래 스크롤바 검색 시 나타나도록 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="343" height="731" alt="image" src="https://github.com/user-attachments/assets/7e647efb-bbd3-4ccf-8e77-5e31788b190b" />

## 💬 공유사항 to 리뷰어
<img width="1402" height="752" alt="image" src="https://github.com/user-attachments/assets/1b2affa9-6cc6-4294-b38f-bea8e53529a7" />

톡방에서 얘기 드린것처럼 다른 프래그먼트 전환시 bottom navi 안보이게 코드 수정했습니다.
homefragmet 뷰 바인딩으로 고쳐뒀습니다.
