### PR TITLE
[Feat] 꿀팁 N분의 1 페이지 구현

### DIFF
--- a/app/src/main/java/com/example/onenthapp/CafeTipsFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/CafeTipsFragment.kt
@@ -1,0 +1,18 @@
+package com.example.onenthapp
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class CafeTipsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_tips_cafetips, container, false)
+    }
+}

--- a/app/src/main/java/com/example/onenthapp/DiscountTipsFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/DiscountTipsFragment.kt
@@ -1,0 +1,18 @@
+package com.example.onenthapp
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class DiscountTipsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_tips_discounttips, container, false)
+    }
+}

--- a/app/src/main/java/com/example/onenthapp/HomeFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/HomeFragment.kt
@@ -17,6 +17,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.naver.maps.map.MapFragment
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
+import androidx.navigation.fragment.findNavController
+
 
 class HomeFragment : Fragment(), OnMapReadyCallback {
     private var _binding: FragmentHomeBinding? = null
@@ -67,6 +69,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     }
                     R.id.menu_tip_n_1 -> {
                         // “꿀팁 N분의1” 선택 처리
+                        parentFragmentManager.beginTransaction()
+                        findNavController().navigate(R.id.tipFragment)
                         true
                     }
                     else -> false
@@ -195,5 +199,5 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 //                true
 //            } else false
 //        }
-        }
+    }
 }

--- a/app/src/main/java/com/example/onenthapp/LifeTipsFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/LifeTipsFragment.kt
@@ -1,0 +1,18 @@
+package com.example.onenthapp
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class LifeTipsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_tips_lifetips, container, false)
+    }
+}

--- a/app/src/main/java/com/example/onenthapp/TipFragment.kt
+++ b/app/src/main/java/com/example/onenthapp/TipFragment.kt
@@ -1,0 +1,133 @@
+package com.example.onenthapp
+
+import android.os.Bundle
+import android.view.*
+import android.view.inputmethod.EditorInfo
+import android.widget.ImageView
+import android.widget.ImageButton
+import android.widget.PopupMenu
+import androidx.appcompat.view.ContextThemeWrapper
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.example.onenthapp.databinding.FragmentTipBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.tabs.TabLayoutMediator
+
+class TipFragment : Fragment() {
+    private var _binding: FragmentTipBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<*>
+    private var sheetInitialized = false
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentTipBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val tabLayout = binding.tabLayoutTips
+        val viewPager = binding.viewPagerTips
+        val ivArrow = binding.ivArrow
+
+        val fragments = listOf(
+            DiscountTipsFragment(),
+            LifeTipsFragment(),
+            CafeTipsFragment()
+        )
+        val titles = listOf("할인 정보", "생활꿀팁", "우리동네 맛집/카페")
+
+        viewPager.adapter = object : FragmentStateAdapter(this@TipFragment) {
+            override fun getItemCount() = fragments.size
+            override fun createFragment(position: Int) = fragments[position]
+        }
+
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            tab.text = titles[position]
+        }.attach()
+
+        val popup = PopupMenu(
+            ContextThemeWrapper(requireContext(), R.style.Theme_OneNthApp),
+            ivArrow,
+            Gravity.END
+        ).apply {
+            menuInflater.inflate(R.menu.menu_title_dropdown, menu)
+            setOnMenuItemClickListener { item ->
+                when (item.itemId) {
+                    R.id.menu_n_1 -> {
+                        findNavController().navigate(R.id.homeFragment)
+                        true
+                    }
+                    R.id.menu_tip_n_1 -> true
+                    else -> false
+                }
+            }
+            setOnDismissListener {
+                ivArrow.animate().rotation(0f).start()
+            }
+        }
+
+        ivArrow.setOnClickListener {
+            ivArrow.animate().rotation(180f).start()
+            popup.show()
+        }
+
+        binding.searchBarEt.setOnEditorActionListener { et, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                performSearch(et.text.toString())
+                if (!sheetInitialized) {
+                    initBottomSheet()
+                    sheetInitialized = true
+                }
+                bottomSheetBehavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
+                true
+            } else false
+        }
+    }
+
+    private fun performSearch(query: String) {
+        // 바텀시트에 검색어 표시
+        binding.tvSearchKeyword.text = query
+    }
+
+
+
+
+    private fun initBottomSheet() {
+        val sheet = binding.bottomSheet
+        sheet.visibility = View.VISIBLE
+        bottomSheetBehavior = BottomSheetBehavior.from(sheet).apply {
+            isHideable = false
+            skipCollapsed = false
+            state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+
+        bottomSheetBehavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
+            override fun onStateChanged(bottomSheet: View, newState: Int) {
+                val isExpanded = newState == BottomSheetBehavior.STATE_EXPANDED
+                binding.minimalContainer.visibility = if (isExpanded) View.GONE else View.VISIBLE
+                binding.expandedContainer.visibility = if (isExpanded) View.VISIBLE else View.GONE
+                binding.scrollBar.visibility = if (isExpanded) View.GONE else View.VISIBLE
+            }
+
+            override fun onSlide(bottomSheet: View, slideOffset: Float) {}
+        })
+
+        binding.rvSearchResults.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+        }
+
+        binding.toolbarSearch.setNavigationOnClickListener {
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+        }
+    }
+}

--- a/app/src/main/res/drawable/material_symbols_bookmark_rounded.xml
+++ b/app/src/main/res/drawable/material_symbols_bookmark_rounded.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M17,3.5C17.416,3.5 17.76,3.642 18.06,3.941C18.358,4.24 18.5,4.584 18.5,4.999V17.975C18.5,18.522 18.285,18.92 17.826,19.22C17.368,19.519 16.91,19.559 16.396,19.34H16.395L12.197,17.54L12,17.456L11.803,17.54L7.604,19.34C7.089,19.559 6.631,19.518 6.173,19.219C5.715,18.92 5.5,18.523 5.5,17.975V5C5.5,4.584 5.643,4.24 5.941,3.941C6.203,3.68 6.499,3.539 6.848,3.507L7.001,3.5H17Z"
+      android:fillColor="#1E1E1E"
+      android:fillAlpha="0.5"
+      android:strokeColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/layout/fragment_tip.xml
+++ b/app/src/main/res/layout/fragment_tip.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/main_white">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/main_white">
+
+        <!-- 1. 툴바 -->
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_tip"
+            android:layout_width="match_parent"
+            android:layout_height="70dp"
+            android:background="@color/main_white"
+            app:popupTheme="@style/ThemeOverlay.MaterialComponents.Light"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <LinearLayout
+                android:id="@+id/ll_title_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/tv_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="30dp"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginBottom="2dp"
+                    android:text="꿀팁 N분의 1"
+                    android:textColor="@color/main_green"
+                    android:textSize="25sp"
+                    android:fontFamily="@font/pretendard_bold"/>
+
+                <ImageView
+                    android:id="@+id/iv_arrow"
+                    android:layout_width="27dp"
+                    android:layout_height="27dp"
+                    android:layout_marginStart="7dp"
+                    android:src="@drawable/ic_down_green"/>
+
+                <ImageButton
+                    android:id="@+id/bt_notification"
+                    android:layout_width="18dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="179dp"
+                    android:src="@drawable/ic_alarmbell"/>
+            </LinearLayout>
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <!-- 2. 검색창 -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/search_bar"
+            android:layout_width="0dp"
+            android:layout_height="35dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            app:cardCornerRadius="10dp"
+            app:cardElevation="3dp"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_tip"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/search_gray"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="12dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_search_glasses"
+                    app:tint="@color/text_search" />
+
+                <EditText
+                    android:id="@+id/search_bar_et"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_weight="1"
+                    android:background="@null"
+                    android:hint="@string/searchbar_guide"
+                    android:textColor="@color/main_black"
+                    android:textColorHint="@color/text_search"
+                    android:textSize="14sp"
+                    android:imeOptions="actionSearch"
+                    android:inputType="text"/>
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- 3. 탭 -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayoutTips"
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:background="@color/main_white"
+            app:tabIndicatorFullWidth="false"
+            app:tabMode="fixed"
+            app:tabSelectedTextColor="@color/main_green"
+            app:tabIndicatorColor="@color/main_green"
+            app:tabTextAppearance="@style/TextAppearance.OneNthApp.Tab"
+            android:layout_marginTop="10dp"
+            app:layout_constraintTop_toBottomOf="@id/search_bar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="할인 정보"/>
+
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="생활 꿀팁"/>
+
+            <com.google.android.material.tabs.TabItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="우리동네 맛집/카페"/>
+
+        </com.google.android.material.tabs.TabLayout>
+
+        <!-- 4. ViewPager -->
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPagerTips"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/tabLayoutTips"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 5. 바텀시트 (※ 반드시 CoordinatorLayout의 자식이어야 함) -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bottom_sheet"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@drawable/bg_bottom_sheet"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+        app:behavior_hideable="false"
+        app:behavior_skipCollapsed="false"
+        app:behavior_peekHeight="@dimen/bottom_sheet_peek_height"
+        app:behavior_fitToContents="false"
+        app:behavior_expandedOffset="0dp"
+        android:elevation="20dp">
+
+        <View
+            android:id="@+id/scroll_bar"
+            android:layout_width="60dp"
+            android:layout_height="4dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:background="@drawable/ic_scrollbar_bar"/>
+
+        <FrameLayout
+            android:id="@+id/minimalContainer"
+            android:layout_width="match_parent"
+            android:layout_height="130dp"
+            app:layout_constraintTop_toBottomOf="@id/scroll_bar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:textSize="16sp" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:id="@+id/expandedContainer"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/minimalContainer"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_search"
+                android:layout_width="match_parent"
+                android:layout_height="120dp"
+                android:background="@color/main_white"
+                app:navigationIcon="@drawable/ep_arrow_up_bold">
+
+                <TextView
+                    style="@style/PretendardH2"
+                    android:id="@+id/tv_search_keyword"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="검색어"
+                    android:textColor="@color/main_green"
+                    android:layout_gravity="center"/>
+
+                <ImageView
+                    android:id="@+id/iv_notification"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="end|center_vertical"
+                    android:layout_marginTop="80dp"
+                    android:layout_marginEnd="50dp"
+                    android:src="@drawable/ic_alarmbell"
+                    android:contentDescription="알림"/>
+            </com.google.android.material.appbar.MaterialToolbar>
+
+
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_search_results"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_tips_cafetips.xml
+++ b/app/src/main/res/layout/fragment_tips_cafetips.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_tips_discounttips.xml
+++ b/app/src/main/res/layout/fragment_tips_discounttips.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_tips_lifetips.xml
+++ b/app/src/main/res/layout/fragment_tips_lifetips.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <!-- 카드 박스처럼 보이는 큰 틀 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:padding="12dp"
+            android:background="@android:color/white"
+            android:elevation="0dp"
+            android:outlineProvider="none"
+            android:clipToPadding="false"
+            android:clipChildren="false"
+            android:backgroundTint="@android:color/white">
+
+            <!-- 제목 -->
+            <TextView
+                android:id="@+id/tvTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="곰팡이 제거제"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:textColor="@android:color/black"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/ivBookmark" />
+
+            <!-- 북마크 아이콘 -->
+            <ImageView
+                android:id="@+id/ivBookmark"
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/material_symbols_bookmark_rounded"
+                android:layout_marginEnd="4dp"
+                app:layout_constraintTop_toTopOf="@id/tvTitle"
+                app:layout_constraintEnd_toStartOf="@id/tvTime" />
+
+            <!-- 시간 -->
+            <TextView
+                android:id="@+id/tvTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="3분전"
+                android:textSize="12sp"
+                android:textColor="#888888"
+                app:layout_constraintTop_toTopOf="@id/tvTitle"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <!-- 내용 -->
+            <TextView
+                android:id="@+id/tvContent"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="000 곰팡이 제거제 어떤가요"
+                android:textSize="13sp"
+                android:textColor="#444444"
+                android:layout_marginTop="4dp"
+                app:layout_constraintTop_toBottomOf="@id/tvTitle"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <!-- 댓글/좋아요/조회수 row -->
+            <LinearLayout
+                android:id="@+id/layoutBottomRow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="4dp"
+                android:gravity="center_vertical"
+                app:layout_constraintTop_toBottomOf="@id/tvContent"
+                app:layout_constraintStart_toStartOf="parent">
+
+                <!-- 댓글 아이콘 -->
+                <ImageView
+                    android:id="@+id/iconComment"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_board_comment" />
+
+                <!-- 댓글 수 -->
+                <TextView
+                    android:id="@+id/tvComment"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:text="2"
+                    android:textSize="12sp"
+                    android:textColor="@color/main_black" />
+
+                <!-- 좋아요 아이콘 -->
+                <ImageView
+                    android:id="@+id/iconLike"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="12dp"
+                    android:src="@drawable/ic_board_like" />
+
+                <!-- 좋아요 수 -->
+                <TextView
+                    android:id="@+id/tvLike"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:text="1"
+                    android:textSize="12sp"
+                    android:textColor="@color/main_black" />
+
+                <!-- 조회수 -->
+                <TextView
+                    android:id="@+id/tvViews"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:text="조회수 24"
+                    android:textSize="12sp"
+                    android:textColor="@color/main_black" />
+            </LinearLayout>
+
+            <!-- 하단 선 -->
+            <View
+                android:id="@+id/bottomDivider"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:layout_marginTop="8dp"
+                android:background="#DDDDDD"
+                app:layout_constraintTop_toBottomOf="@id/layoutBottomRow"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -32,4 +32,11 @@
         tools:layout="@layout/fragment_plus"
         />
 
+    <fragment
+        android:id="@+id/tipFragment"
+        android:name="com.example.onenthapp.TipFragment"
+        android:label="꿀팁 N분의 1"
+        tools:layout="@layout/fragment_tip" />
+
+
 </navigation>


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#24 
#25 
## 📝 요약(Summary)

<!---변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
메인화면에서 상단 N분의 1 클릭 시 각 페이지로 이동(꿀팁 N분의 1)
할인 정보, 생활 꿀팁, 우리동네 맛집/카페 탭 레이아웃 생성
검색 시 검색 화면 페이지에서 검색 텍스트 연동
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
꿀팁 N분의 1페이지에서 탭 레이아웃 각각 페이지 아래 Fragment, xml 파일로 연결해두었습니다
할인정보-> DiscountTipsFragment/ fragment_tips_discounttips
생활꿀팁-> LifeTipsFragment/ fragment_tips_lifetips
우리동네 맛집/카페 -> CafeTipsFragment / fragment_tips_cafetips
